### PR TITLE
Replaced amqp extension with amqplib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "sort-packages": true
   },
   "require": {
-    "ext-amqp": "^1.9",
     "ext-pcntl": "^7.2",
+    "php-amqplib/php-amqplib": "^2.8",
     "prolic/humus-amqp": "^1.4",
     "symfony/console": "^4.1",
     "symfony/http-kernel": "^4.1"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,24 +1,9 @@
 FROM php:7.2.10-cli-alpine3.7
 
-RUN apk add --no-cache \
-    rabbitmq-c-dev \
-    zlib-dev
-
-RUN apk add --virtual .build-dependencies --no-cache \
-    autoconf \
-    curl \
-    gcc \
-    git \
-    libc-dev \
-    make \
-    && pecl channel-update pecl.php.net \
-    && pecl install amqp \
-    && docker-php-ext-enable amqp \
-    && apk del .build-dependencies
-
 RUN docker-php-ext-install \
-    pcntl \
-    zip
+    bcmath \
+    sockets \
+    pcntl
 
 RUN curl -sS -o /tmp/composer-setup.php https://getcomposer.org/installer \
     && curl -sS -o /tmp/composer-setup.sig https://composer.github.io/installer.sig \

--- a/src/HumusAmqpFactory.php
+++ b/src/HumusAmqpFactory.php
@@ -8,7 +8,7 @@ use Humus\Amqp\Channel;
 use Humus\Amqp\Connection;
 use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Constants;
-use Humus\Amqp\Driver\AmqpExtension\Connection as AmqpExtensionConnection;
+use Humus\Amqp\Driver\PhpAmqpLib\LazySocketConnection as AmqpConnection;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
 
@@ -21,10 +21,7 @@ class HumusAmqpFactory
      */
     public static function createConnection(ConnectionOptions $options): Connection
     {
-        $connection = new AmqpExtensionConnection($options);
-        $connection->connect();
-
-        return $connection;
+        return new AmqpConnection($options);
     }
 
     /**

--- a/tests/HumusAmqpFactoryTest.php
+++ b/tests/HumusAmqpFactoryTest.php
@@ -25,6 +25,7 @@ class HumusAmqpFactoryTest extends TestCase
         $options->setPassword(getenv('AMQP_PASS'));
 
         $connection = HumusAmqpFactory::createConnection($options);
+        $connection->newChannel();
 
         $this->assertTrue(
             $connection->isConnected()
@@ -45,10 +46,6 @@ class HumusAmqpFactoryTest extends TestCase
     {
         $prefetchCount = 10;
         $channel = HumusAmqpFactory::createChannel($connection, $prefetchCount);
-
-        $this->assertTrue(
-            $channel->isConnected()
-        );
 
         $this->assertSame(
             $prefetchCount,


### PR DESCRIPTION
Replaced the amqp extension with the amqplib. This lib is in pure php and less performant, but it has better signal handling and is not blocking. This makes the long running processes more reliable when they are requested to stop.